### PR TITLE
Reorg cleanup 2nd try

### DIFF
--- a/pdsfile.py
+++ b/pdsfile.py
@@ -4758,7 +4758,10 @@ class PdsFile(object):
         if dir:
             parts += [dir.rstrip('/'), '/']
 
-        parts += [self.category_, self.volset_, self.volname, suffix]
+        parts += [self.category_, self.volset_, self.volname]
+
+        if suffix:
+            parts += ['_', suffix.lstrip('_')]  # exactly one "_" before suffix
 
         timetag = datetime.datetime.now().strftime(LOGFILE_TIME_FMT)
         parts += ['_', timetag]
@@ -4792,7 +4795,10 @@ class PdsFile(object):
         if dir:
             parts += [dir.rstrip('/'), '/']
 
-        parts += [self.category_, self.volset, self.suffix, suffix]
+        parts += [self.category_, self.volset, self.suffix]
+
+        if suffix:
+            parts += ['_', suffix.lstrip('_')]  # exactly one "_" before suffix
 
         timetag = datetime.datetime.now().strftime(LOGFILE_TIME_FMT)
         parts += ['_', timetag]
@@ -4809,6 +4815,9 @@ class PdsFile(object):
 
         The file name is [dir/]<logical_path_wo_ext>_timetag[_task].log.
         """
+
+        if not self.is_index:
+            raise ValueError('Not an index file: ' + self.logical_path)
 
         # This option provides for a temporary override of the default log root
         if place == 'default':

--- a/pdsfile.py
+++ b/pdsfile.py
@@ -141,6 +141,13 @@ CATEGORIES = set(CATEGORY_LIST)
 # Extra description files that can appear in volset directories
 EXTRA_README_BASENAMES = ('AAREADME.txt', 'AAREADME.pdf')
 
+# Directory prefix and file suffix for shelf files
+SHELF_PATH_INFO = {
+    'index': ('_indexshelf-', '_index'),
+    'info' : ('_infoshelf-', '_info'),
+    'link' : ('_linkshelf-', '_links'),
+}
+
 ################################################################################
 # PdsLogger support
 ################################################################################
@@ -2231,7 +2238,7 @@ class PdsFile(object):
         # Otherwise, look up the info in the shelf file
         else:
             try:
-                values = self.shelf_lookup('links')
+                values = self.shelf_lookup('link')
 
             # Shelf file failure
             except (IOError, KeyError, ValueError) as e:
@@ -3928,7 +3935,8 @@ class PdsFile(object):
         if flag is '',  return the selected key even if it doesn't exist.
         """
 
-        assert flag in ('', '=', '>', '<'), 'Invalid flag "%s"' % flag
+        if flag not in ('', '=', '>', '<'):
+            raise ValueError(f'Invalid flag "{flag}"' % flag)
 
         # Truncate the selection key if it is too long
         if self.filename_keylen:
@@ -4269,7 +4277,7 @@ class PdsFile(object):
                 # this label file. That way, the error handled when calling the
                 # linked_abspaths below will not abort the import process.
                 try:
-                    pdsf.shelf_lookup('links')
+                    pdsf.shelf_lookup('link')
                 except (OSError, KeyError, ValueError):
                     LOGGER.warn('Missing links info',
                                 pdsf.logical_path)
@@ -4452,7 +4460,7 @@ class PdsFile(object):
             this.archives_ = ''
             this.category_ = this.voltype_
 
-        return this.log_path_for_volume(id='targz', task=task, dir='archives')
+        return this.log_path_for_volume('_targz', task=task, dir='archives')
 
     ############################################################################
     # Shelf support
@@ -4466,13 +4474,13 @@ class PdsFile(object):
 
     SHELF_NULL_KEY_VALUES = {}
 
-    def shelf_path_and_lskip(self, id='info', volname=''):
+    def shelf_path_and_lskip(self, shelf_type='info', volname=''):
         """The absolute path to the shelf file associated with this PdsFile.
         Also return the number of characters to skip over in that absolute
         path to obtain the key into the shelf.
 
         Inputs:
-            id          shelf type, 'info' or 'link'.
+            shelf_type  shelf type ID: 'index', 'info', or 'link'.
             volname     an optional volume name to append to the end of a this
                         path, which can be used if this is a volset.
         """
@@ -4481,15 +4489,16 @@ class PdsFile(object):
             raise ValueError('No shelf files for checksums: ' +
                              self.logical_path)
 
-        short_id = 'link' if id == 'links' else id
+        (dir_prefix, file_suffix) = SHELF_PATH_INFO[shelf_type]
+
         if self.archives_:
             if not self.volset_:
                 raise ValueError('Archive shelves require volume sets: ' +
                                  self.logical_path)
 
-            abspath = ''.join([self.disk_, 'holdings/_', short_id, 'shelf-',
-                               self.category_, self.volset, self.suffix, '_',
-                               id, '.pickle'])
+            abspath = ''.join([self.root_, dir_prefix,
+                               self.category_, self.volset, self.suffix,
+                               file_suffix, '.pickle'])
             lskip = (len(self.root_) + len(self.category_) +
                      len(self.volset_))
 
@@ -4503,18 +4512,18 @@ class PdsFile(object):
             else:
                 this_volname = self.volname
 
-            abspath = ''.join([self.disk_, 'holdings/_', short_id, 'shelf-',
-                               self.category_, self.volset_, this_volname, '_',
-                               id, '.pickle'])
+            abspath = ''.join([self.root_, dir_prefix,
+                               self.category_, self.volset_, this_volname,
+                               file_suffix, '.pickle'])
             lskip = (len(self.root_) + len(self.category_) +
                      len(self.volset_) + len(this_volname) + 1)
 
         return (abspath, lskip)
 
-    def shelf_path_and_key(self, id='info', volname=''):
+    def shelf_path_and_key(self, shelf_id='info', volname=''):
         """Absolute path to a shelf file, plus the key for this item."""
 
-        (abspath, lskip) = self.shelf_path_and_lskip(id=id, volname=volname)
+        (abspath, lskip) = self.shelf_path_and_lskip(shelf_id, volname)
         if volname:
             return (abspath, '')
         else:
@@ -4602,16 +4611,16 @@ class PdsFile(object):
         for shelf_path in keys:                     # be modified inside loop!
             PdsFile._close_shelf(shelf_path)
 
-    def shelf_lookup(self, id='info', volname=''):
-        """Return the contents of the id's shelf file associated with this
-        object.
+    def shelf_lookup(self, shelf_type='info', volname=''):
+        """Return the contents of a shelf file associated with this object.
 
-        id          indicates the type of the shelf file: 'info' or 'links'.
-        volname     can be used to get info about a volume when the method is
-                    applied to its enclosing volset.
+        shelf_type      indicates the type of the shelf file: 'info', 'link', or
+                        'index'.
+        volname         can be used to get info about a volume when the method
+                        is applied to its enclosing volset.
         """
 
-        (shelf_path, key) = self.shelf_path_and_key(id, volname)
+        (shelf_path, key) = self.shelf_path_and_key(shelf_type, volname)
 
         # This potentially saves the need for a lot of opens and closes when
         # getting info about volumes rather than interior files
@@ -4624,7 +4633,7 @@ class PdsFile(object):
             # Try the second line of the .py file; this is quicker than reading
             # the whole .pickle file. This is useful because it avoids the need
             # to open every info shelf file during preload.
-            if id == 'info':
+            if shelf_type == 'info':
                 py_path = shelf_path.replace('.pickle', '.py')
                 LOGGER.debug('Retrieving key "%s"' % py_path)
 
@@ -4642,18 +4651,20 @@ class PdsFile(object):
         return shelf[key]
 
     @staticmethod
-    def shelf_path_and_key_for_abspath(abspath, id='info'):
+    def shelf_path_and_key_for_abspath(abspath, shelf_type='info'):
         """The absolute path to the shelf file associated with this file path.
         Also return the key for indexing into the shelf.
 
         Inputs:
-            id          shelf type, e.g., 'info' or 'link'.
+            shelf_type      shelf type, e.g., 'info' or 'link'.
         """
 
         # No checksum shelf files allowed
         (root, _, logical_path) = abspath.partition('/holdings/')
         if logical_path.startswith('checksums'):
             raise ValueError('No shelf files for checksums: ' + logical_path)
+
+        (dir_prefix, file_suffix) = SHELF_PATH_INFO[shelf_type]
 
         # For archive files, the shelf is associated with the volset
         if logical_path.startswith('archives'):
@@ -4662,9 +4673,9 @@ class PdsFile(object):
                 raise ValueError('Archive shelves require volume sets: ' +
                                  logical_path)
 
-            shelf_abspath = ''.join([root, '/holdings/_', id, 'shelf-',
-                                     parts[0], '/', parts[1], '_', id,
-                                     '.pickle'])
+            shelf_abspath = ''.join([root, '/holdings/', dir_prefix,
+                                     parts[0], '/', parts[1],
+                                     file_suffix, '.pickle'])
             key = '/'.join(parts[2:])
 
         # Otherwise, the shelf is associated with the volume
@@ -4674,9 +4685,9 @@ class PdsFile(object):
                 raise ValueError('Non-archive shelves require volume names: ' +
                                  logical_path)
 
-            shelf_abspath = ''.join([root, '/holdings/_', id, 'shelf-',
+            shelf_abspath = ''.join([root, '/holdings/', dir_prefix,
                                      parts[0], '/', parts[1], '/', parts[2],
-                                     '_', id, '.pickle'])
+                                     file_suffix, '.pickle'])
             key = '/'.join(parts[3:])
 
         return (shelf_abspath, key)
@@ -4725,10 +4736,10 @@ class PdsFile(object):
         else:
             PdsFile.LOG_ROOT_ = root.rstrip('/') + '/'
 
-    def log_path_for_volume(self, id='', task='', dir='', place='default'):
+    def log_path_for_volume(self, suffix='', task='', dir='', place='default'):
         """Return a complete log file path for this volume.
 
-        The file name is [dir/]category/volset/volname_id_timetag[_task].log.
+        The file name is [dir/]category/volset/volname_suffix_time[_task].log
         """
 
         # This option provides for a temporary override of the default log root
@@ -4747,10 +4758,7 @@ class PdsFile(object):
         if dir:
             parts += [dir.rstrip('/'), '/']
 
-        parts += [self.category_, self.volset_, self.volname]
-
-        if id:
-            parts += ['_', id]
+        parts += [self.category_, self.volset_, self.volname, suffix]
 
         timetag = datetime.datetime.now().strftime(LOGFILE_TIME_FMT)
         parts += ['_', timetag]
@@ -4762,10 +4770,10 @@ class PdsFile(object):
 
         return ''.join(parts)
 
-    def log_path_for_volset(self, id='', task='', dir='', place='default'):
+    def log_path_for_volset(self, suffix='', task='', dir='', place='default'):
         """Return a complete log file path for this volume set.
 
-        The file name is [dir/]category/volset_id_timetag[_task].log.
+        The file name is [dir/]category/volset_suffix_time[_task].log.
         """
 
         # This option provides for a temporary override of the default log root
@@ -4784,10 +4792,7 @@ class PdsFile(object):
         if dir:
             parts += [dir.rstrip('/'), '/']
 
-        parts += [self.category_, self.volset, self.suffix]
-
-        if id:
-            parts += ['_', id]
+        parts += [self.category_, self.volset, self.suffix, suffix]
 
         timetag = datetime.datetime.now().strftime(LOGFILE_TIME_FMT)
         parts += ['_', timetag]

--- a/pdsfile_rules.py
+++ b/pdsfile_rules.py
@@ -551,7 +551,7 @@ OPUS_ID = translator.TranslatorByRegex([])
 ####################################################################################################################################
 # OPUS_ID_TO_SUBCLASS
 #
-# Translates an OPUS ID to a PdsFile subclass
+# Translates an OPUS ID to a PdsFile subclass.
 ####################################################################################################################################
 
 OPUS_ID_TO_SUBCLASS = translator.TranslatorByRegex([])

--- a/rules/NHSP_xxxx.py
+++ b/rules/NHSP_xxxx.py
@@ -40,6 +40,9 @@ class NHSP_xxxx(pdsfile.PdsFile):
     pdsfile.PdsFile.VOLSET_TRANSLATOR = translator.TranslatorByRegex([('NHSP_xxxx.*', re.I, 'NHSP_xxxx')]) + \
                                         pdsfile.PdsFile.VOLSET_TRANSLATOR
 
+    ASSOCIATIONS = pdsfile.PdsFile.ASSOCIATIONS.copy()
+    ASSOCIATIONS['documents'] += associations_to_documents
+
     INFO_FILE_BASENAMES = info_file_basenames + pdsfile.PdsFile.INFO_FILE_BASENAMES
 
 pdsfile.PdsFile.FILESPEC_TO_VOLSET = filespec_to_volset + pdsfile.PdsFile.FILESPEC_TO_VOLSET

--- a/tests/test_pdsfile_blackbox.py
+++ b/tests/test_pdsfile_blackbox.py
@@ -1410,86 +1410,132 @@ class TestPdsFileBlackBox:
     # Test for log path associations
     ############################################################################
     @pytest.mark.parametrize(
-        'root,expected',
+        'input_path,suffix,task,dir,place,logroot,expected',
         [
-            (None, None),
-            (PDS_PDSDATA_PATH + 'logs/', PDS_PDSDATA_PATH + 'logs/')
-        ]
-    )
-    def test_set_log_root(self, root, expected):
-        pdsfile.PdsFile.set_log_root(root=root)
-        assert pdsfile.PdsFile.LOG_ROOT_ == expected
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', '', '', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx/HSTI1_1556_20..-..-..T..-..-..\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', '', '', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx/HSTI1_1556_20..-..-..T..-..-..\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', '', '', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx/HSTI1_1556_alligator_20..-..-..T..-..-..\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', '', '', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx/HSTI1_1556_alligator_20..-..-..T..-..-..\.log'),
 
-    @pytest.mark.parametrize(
-        'input_path,expected',
-        [
-            ('volumes/HSTIx_xxxx/HSTI1_1556',
-             PDS_PDSDATA_PATH + 'logs/volumes/HSTIx_xxxx/HSTI1_1556_.*.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', '', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx/HSTI1_1556_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', '', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx/HSTI1_1556_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', '', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx/HSTI1_1556_alligator_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', '', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx/HSTI1_1556_alligator_20..-..-..T..-..-.._wrestle\.log'),
+
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', 'tallahassee', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx/HSTI1_1556_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', 'tallahassee', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx/HSTI1_1556_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', 'tallahassee', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx/HSTI1_1556_alligator_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', 'tallahassee', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx/HSTI1_1556_alligator_20..-..-..T..-..-.._wrestle\.log'),
+
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', 'tallahassee', 'default', '/florida',
+             r'/florida/tallahassee/volumes/HSTIx_xxxx/HSTI1_1556_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', 'tallahassee', 'parallel', '/florida',
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx/HSTI1_1556_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', 'tallahassee', 'default', '/florida',
+             r'/florida/tallahassee/volumes/HSTIx_xxxx/HSTI1_1556_alligator_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', 'tallahassee', 'parallel', '/florida',
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx/HSTI1_1556_alligator_20..-..-..T..-..-.._wrestle\.log'),
         ]
     )
-    def test_log_path_for_volume(self, input_path, expected):
+    def test_log_path_for_volume(self, input_path, suffix, task, dir, place, logroot, expected):
         target_pdsfile = instantiate_target_pdsfile(input_path)
-        res = target_pdsfile.log_path_for_volume(id='', task='', dir='')
+        pdsfile.PdsFile.set_log_root(logroot)
+        res = target_pdsfile.log_path_for_volume(suffix, task, dir, place)
+        pdsfile.PdsFile.set_log_root()
         # escape possible "(" & ")" if that exists in PDS_PDSDATA_PATH
         expected = expected.replace('(', '\\(')
         expected = expected.replace(')', '\\)')
         assert re.match(expected, res)
 
     @pytest.mark.parametrize(
-        'input_path,expected',
+        'input_path,suffix,task,dir,place,logroot,expected',
         [
-            ('volumes/HSTIx_xxxx/HSTI1_1556',
-             PDS_PDSDATA_PATH + 'logs/volumes/HSTIx_xxxx_.*.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', '', '', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx_20..-..-..T..-..-..\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', '', '', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx_20..-..-..T..-..-..\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', '', '', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx_alligator_20..-..-..T..-..-..\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', '', '', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx_alligator_20..-..-..T..-..-..\.log'),
+
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', '', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', '', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', '', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx_alligator_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', '', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/volumes/HSTIx_xxxx_alligator_20..-..-..T..-..-.._wrestle\.log'),
+
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', 'tallahassee', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', 'tallahassee', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', 'tallahassee', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx_alligator_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', 'tallahassee', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx_alligator_20..-..-..T..-..-.._wrestle\.log'),
+
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', 'tallahassee', 'default', '/florida',
+             r'/florida/tallahassee/volumes/HSTIx_xxxx_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', '', 'wrestle', 'tallahassee', 'parallel', '/florida',
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', 'tallahassee', 'default', '/florida',
+             r'/florida/tallahassee/volumes/HSTIx_xxxx_alligator_20..-..-..T..-..-.._wrestle\.log'),
+            ('volumes/HSTIx_xxxx/HSTI1_1556', 'alligator', 'wrestle', 'tallahassee', 'parallel', '/florida',
+             PDS_PDSDATA_PATH + r'logs/tallahassee/volumes/HSTIx_xxxx_alligator_20..-..-..T..-..-.._wrestle\.log'),
         ]
     )
-    def test_log_path_for_volset(self, input_path, expected):
+    def test_log_path_for_volset(self, input_path, suffix, task, dir, place, logroot, expected):
         target_pdsfile = instantiate_target_pdsfile(input_path)
-        res = target_pdsfile.log_path_for_volset()
+        pdsfile.PdsFile.set_log_root(logroot)
+        res = target_pdsfile.log_path_for_volset(suffix, task, dir, place)
+        pdsfile.PdsFile.set_log_root()
         # escape possible "(" & ")" if that exists in PDS_PDSDATA_PATH
         expected = expected.replace('(', '\\(')
         expected = expected.replace(')', '\\)')
         assert re.match(expected, res)
 
     @pytest.mark.parametrize(
-        'input_path,expected',
+        'input_path,task,dir,place,logroot,expected',
         [
-            ('volumes/HSTIx_xxxx/HSTI1_1556',
-             PDS_PDSDATA_PATH + 'logs/volumes/HSTIx_xxxx_.*.log'),
-        ]
-    )
-    def test_log_path_for_volset2(self, input_path, expected):
-        target_pdsfile = instantiate_target_pdsfile(input_path)
-        res = target_pdsfile.log_path_for_volset(place='parallel')
-        # escape possible "(" & ")" if that exists in PDS_PDSDATA_PATH
-        expected = expected.replace('(', '\\(')
-        expected = expected.replace(')', '\\)')
-        assert re.match(expected, res)
+            ('metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles.tab', '', '', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles_20..-..-..T..-..-..\.log'),
+            ('metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles.tab', '', '', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles_20..-..-..T..-..-..\.log'),
+            ('metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles.tab', 'scramble', '', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles_20..-..-..T..-..-.._scramble\.log'),
+            ('metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles.tab', 'scramble', '', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles_20..-..-..T..-..-.._scramble\.log'),
 
-    @pytest.mark.parametrize(
-        'input_path,expected',
-        [
-            ('volumes/HSTIx_xxxx/HSTI1_1556',
-             PDS_PDSDATA_PATH + 'logs/index/_.*.log'),
+            ('metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles.tab', 'scramble', 'eggs', 'default', None,
+             PDS_PDSDATA_PATH + r'logs/eggs/metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles_20..-..-..T..-..-.._scramble\.log'),
+            ('metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles.tab', 'scramble', 'eggs', 'parallel', None,
+             PDS_PDSDATA_PATH + r'logs/eggs/metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles_20..-..-..T..-..-.._scramble\.log'),
+            ('metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles.tab', 'scramble', 'eggs', 'default', '/green',
+             r'/green/eggs/metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles_20..-..-..T..-..-.._scramble\.log'),
+            ('metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles.tab', 'scramble', 'eggs', 'parallel', '/green',
+             PDS_PDSDATA_PATH + r'logs/eggs/metadata/HSTIx_xxxx/HSTI1_1556/HSTI1_1556_hstfiles_20..-..-..T..-..-.._scramble\.log'),
         ]
     )
-    def test_log_path_for_index(self, input_path, expected):
+    def test_log_path_for_index(self, input_path, task, dir, place, logroot, expected):
         target_pdsfile = instantiate_target_pdsfile(input_path)
-        res = target_pdsfile.log_path_for_index()
-        # escape possible "(" & ")" if that exists in PDS_PDSDATA_PATH
-        expected = expected.replace('(', '\\(')
-        expected = expected.replace(')', '\\)')
-        assert re.match(expected, res)
-
-    @pytest.mark.parametrize(
-        'input_path,expected',
-        [
-            ('volumes/HSTIx_xxxx/HSTI1_1556',
-             PDS_PDSDATA_PATH + 'logs/index/_.*.log'),
-        ]
-    )
-    def test_log_path_for_index2(self, input_path, expected):
-        target_pdsfile = instantiate_target_pdsfile(input_path)
-        res = target_pdsfile.log_path_for_index(place='parallel')
+        pdsfile.PdsFile.set_log_root(logroot)
+        res = target_pdsfile.log_path_for_index(task, dir, place)
+        pdsfile.PdsFile.set_log_root()
         # escape possible "(" & ")" if that exists in PDS_PDSDATA_PATH
         expected = expected.replace('(', '\\(')
         expected = expected.replace(')', '\\)')

--- a/tests/test_pdsfile_whitebox.py
+++ b/tests/test_pdsfile_whitebox.py
@@ -712,24 +712,8 @@ class TestPdsFileWhiteBox:
             assert path in expected
 
     ############################################################################
-    # Test for log path associations
+    # Test for path associations
     ############################################################################
-    @pytest.mark.parametrize(
-        'input_path,expected',
-        [
-            ('volumes/HSTIx_xxxx/HSTI1_1556',
-             PDS_PDSDATA_PATH + 'logs/volumes/HSTIx_xxxx/HSTI1_1556_.*.log'),
-        ]
-    )
-    def test_log_path_for_volume(self, input_path, expected):
-        target_pdsfile = instantiate_target_pdsfile(input_path)
-        res = target_pdsfile.log_path_for_volume(id='', task='', dir='',
-                                                 place='parallel')
-        # escape possible "(" & ")" if that exists in PDS_PDSDATA_PATH
-        expected = expected.replace('(', '\\(')
-        expected = expected.replace(')', '\\)')
-        assert re.match(expected, res)
-
     @pytest.mark.parametrize(
         'input_path,expected',
         [

--- a/validation/pdsarchives.py
+++ b/validation/pdsarchives.py
@@ -4,7 +4,7 @@
 #
 # Syntax:
 #   pdsarchives.py --task path [path ...]
-# 
+#
 # Enter the --help option to see more information.
 ################################################################################
 
@@ -442,10 +442,10 @@ if __name__ == '__main__':
         for pdsdir in pdsdirs:
 
             # Save logs in up to two places
-            logfiles = set([pdsdir.log_path_for_volume(id='links',
+            logfiles = set([pdsdir.log_path_for_volume('_links',
                                                        task=args.task,
                                                        dir='pdsarchives'),
-                            pdsdir.log_path_for_volume(id='links',
+                            pdsdir.log_path_for_volume('_links',
                                                        task=args.task,
                                                        dir='pdsarchives',
                                                        place='parallel')])
@@ -464,7 +464,7 @@ if __name__ == '__main__':
             # Open the next level of the log
             if len(pdsdirs) > 1:
                 logger.blankline()
- 
+
             logger.open('Task %s for' % args.task, pdsdir.abspath,
                                                    handler=local_handlers)
 

--- a/validation/pdschecksums.py
+++ b/validation/pdschecksums.py
@@ -4,7 +4,7 @@
 #
 # Syntax:
 #   pdschecksums.py --task path [path ...]
-# 
+#
 # Enter the --help option to see more information.
 ################################################################################
 
@@ -100,7 +100,7 @@ def generate_checksums(pdsdir, selection=None, oldpairs=[], regardless=True,
                 elif abspath in md5_dict:
                     newtuples.append((abspath, md5_dict[abspath], file))
                     logger.debug('MD5 copied', abspath)
-    
+
                 else:
                     md5 = hashfile(abspath)
                     newtuples.append((abspath, md5, file))
@@ -112,7 +112,7 @@ def generate_checksums(pdsdir, selection=None, oldpairs=[], regardless=True,
                 return ({}, latest_mtime)
 
             if len(newtuples) > 1:
-                logger.error('Multiple copies of file selection found', 
+                logger.error('Multiple copies of file selection found',
                              selection)
                 return ({}, latest_mtime)
 
@@ -127,7 +127,7 @@ def generate_checksums(pdsdir, selection=None, oldpairs=[], regardless=True,
         for key in old_keys:
             newpairs.append((key, md5_dict[key]))
             del md5_dict[key]
- 
+
         for (key, new_md5, new_file) in newtuples:
             if key in md5_dict:     # if not already copied to list of pairs
                 newpairs.append((key, md5_dict[key]))
@@ -271,7 +271,7 @@ def write_checksums(check_path, abspairs,
 
             f.write('%s  %s\n' % (hex, abspath[lskip:]))
             logger.debug('Written', abspath)
-    
+
         f.close()
 
     except (Exception, KeyboardInterrupt) as e:
@@ -635,12 +635,12 @@ if __name__ == '__main__':
     parser.add_argument('--quiet', '-q', action='store_true',
                         help='Do not also log to the terminal.')
 
-    parser.add_argument('--archives', '-a', default=False, action='store_true', 
+    parser.add_argument('--archives', '-a', default=False, action='store_true',
                         help='Instead of referring to a volume, refer to the ' +
                              'the archive file for that volume.')
 
     parser.add_argument('--infoshelf', '-i', dest='infoshelf',
-                        default=False, action='store_true', 
+                        default=False, action='store_true',
                         help='After a successful run, also execute the '       +
                              'equivalent pdsinfoshelf command.')
 
@@ -768,18 +768,18 @@ if __name__ == '__main__':
 
             # Save logs in up to two places
             if pdsf.volname:
-                logfiles = set([pdsf.log_path_for_volume(id='md5',
+                logfiles = set([pdsf.log_path_for_volume('_md5',
                                                          task=args.task,
                                                          dir='pdschecksums'),
-                                pdsf.log_path_for_volume(id='md5',
+                                pdsf.log_path_for_volume('_md5',
                                                          task=args.task,
                                                          dir='pdschecksums',
                                                          place='parallel')])
             else:
-                logfiles = set([pdsf.log_path_for_volset(id='md5',
+                logfiles = set([pdsf.log_path_for_volset('_md5',
                                                          task=args.task,
                                                          dir='pdschecksums'),
-                                pdsf.log_path_for_volset(id='md5',
+                                pdsf.log_path_for_volset('_md5',
                                                          task=args.task,
                                                          dir='pdschecksums',
                                                          place='parallel')])
@@ -800,7 +800,7 @@ if __name__ == '__main__':
             # Open the next level of the log
             if len(info) > 1:
                 logger.blankline()
- 
+
             if selection:
                 logger.open('Task "' + args.task + '" for selection ' +
                             selection, path, handler=local_handlers)

--- a/validation/pdsdependency.py
+++ b/validation/pdsdependency.py
@@ -370,8 +370,8 @@ _ = PdsDependency(
     'Newer index shelf for every metadata table',
     'metadata/$*/$/*.tab',
     r'metadata/(.*)\.tab',
-    [r'_infoshelf-metadata/\1.pickle',
-     r'_infoshelf-metadata/\1.py'],
+    [r'_indexshelf-metadata/\1.pickle',
+     r'_indexshelf-metadata/\1.py'],
     suite='metadata', newer=True,
     exceptions=[r'.*_inventory.tab',
                 r'.*GO_0xxx_v1.*']
@@ -899,9 +899,9 @@ if __name__ == '__main__':
             pdsdir = pdsfile.PdsFile.from_abspath(path)
 
             # Save logs in up to two places
-            logfiles = set([pdsdir.log_path_for_volume(id='dependency',
+            logfiles = set([pdsdir.log_path_for_volume('_dependency',
                                                        dir='pdsdependency'),
-                            pdsdir.log_path_for_volume(id='dependency',
+                            pdsdir.log_path_for_volume('_dependency',
                                                        dir='pdsdependency',
                                                        place='parallel')])
 

--- a/validation/pdsinfoshelf.py
+++ b/validation/pdsinfoshelf.py
@@ -195,7 +195,7 @@ def load_infodict(pdsdir, logger=None):
     logger.open('Reading info shelf file for', dirpath_[:-1])
 
     try:
-        (info_path, lskip) = pdsdir.shelf_path_and_lskip(id='info')
+        (info_path, lskip) = pdsdir.shelf_path_and_lskip('info')
         logger.info('Info shelf file', info_path)
 
         if not os.path.exists(info_path):
@@ -240,7 +240,7 @@ def write_infodict(pdsdir, infodict, limits={}, logger=None):
     logger.open('Writing info file info for', dirpath, limits=limits)
 
     try:
-        (info_path, lskip) = pdsdir.shelf_path_and_lskip(id='info')
+        (info_path, lskip) = pdsdir.shelf_path_and_lskip('info')
         logger.info('Info shelf file', info_path)
 
         # Create parent directory if necessary
@@ -428,7 +428,7 @@ def move_old_info(shelf_file, logger=None):
 
 def initialize(pdsdir, selection=None, logger=None):
 
-    info_path = pdsdir.shelf_path_and_lskip(id='info')[0]
+    info_path = pdsdir.shelf_path_and_lskip('info')[0]
 
     # Make sure file does not exist
     if os.path.exists(info_path):
@@ -450,7 +450,7 @@ def initialize(pdsdir, selection=None, logger=None):
 
 def reinitialize(pdsdir, selection=None, logger=None):
 
-    info_path = pdsdir.shelf_path_and_lskip(id='info')[0]
+    info_path = pdsdir.shelf_path_and_lskip('info')[0]
 
     # Warn if shelf file does not exist
     if not os.path.exists(info_path):
@@ -477,7 +477,7 @@ def reinitialize(pdsdir, selection=None, logger=None):
 
 def validate(pdsdir, selection=None, logger=None):
 
-    info_path = pdsdir.shelf_path_and_lskip(id='info')[0]
+    info_path = pdsdir.shelf_path_and_lskip('info')[0]
 
     # Make sure file exists
     if not os.path.exists(info_path):
@@ -497,7 +497,7 @@ def validate(pdsdir, selection=None, logger=None):
 
 def repair(pdsdir, selection=None, logger=None):
 
-    info_path = pdsdir.shelf_path_and_lskip(id='info')[0]
+    info_path = pdsdir.shelf_path_and_lskip('info')[0]
 
     # Make sure file exists
     if not os.path.exists(info_path):
@@ -568,7 +568,7 @@ def repair(pdsdir, selection=None, logger=None):
 
 def update(pdsdir, selection=None, logger=None):
 
-    info_path = pdsdir.shelf_path_and_lskip(id='info')[0]
+    info_path = pdsdir.shelf_path_and_lskip('info')[0]
 
     # Make sure info shelf file exists
     if not os.path.exists(info_path):
@@ -791,7 +791,7 @@ if __name__ == '__main__':
     try:
         for (pdsdir, selection) in info:
 
-            info_path = pdsdir.shelf_path_and_lskip(id='info')[0]
+            info_path = pdsdir.shelf_path_and_lskip('info')[0]
 
             if selection:
                 pdsf = pdsdir.child(os.path.basename(selection))
@@ -800,18 +800,18 @@ if __name__ == '__main__':
 
             # Save logs in up to two places
             if pdsf.volname:
-                logfiles = set([pdsf.log_path_for_volume(id='info',
+                logfiles = set([pdsf.log_path_for_volume('_info',
                                                          task=args.task,
                                                          dir='pdsinfoshelf'),
-                                pdsf.log_path_for_volume(id='info',
+                                pdsf.log_path_for_volume('_info',
                                                          task=args.task,
                                                          dir='pdsinfoshelf',
                                                          place='parallel')])
             else:
-                logfiles = set([pdsf.log_path_for_volset(id='info',
+                logfiles = set([pdsf.log_path_for_volset('_info',
                                                          task=args.task,
                                                          dir='pdsinfoshelf'),
-                                pdsf.log_path_for_volset(id='info',
+                                pdsf.log_path_for_volset('_info',
                                                          task=args.task,
                                                          dir='pdsinfoshelf',
                                                          place='parallel')])

--- a/validation/pdslinkshelf.py
+++ b/validation/pdslinkshelf.py
@@ -364,7 +364,7 @@ REPAIRS = translator.TranslatorByRegex([
       translator.TranslatorByDict(
         {'JUNO_REF.CAT'         : 'JUNO_PROJREF.CAT'})),
 
-    # NHSP
+    # NHSP (and *SP_xxxx)
     ('.*/NHSP_xxxx_v1.*/AAREADME\.TXT', 0,
       translator.TranslatorByDict(
         {'personel.cat'         : 'CATALOG/PERSONNEL.CAT',
@@ -403,7 +403,8 @@ REPAIRS = translator.TranslatorByRegex([
          'SOC_INST_ICD.LBL'     : 'DOCUMENT/SOC_INST_ICD/SOC_INST_ICD.LBL'})),
     ('.*/NHxxLO_xxxx.*/NH..LO_2001/data/\w+/.*\.lbl', 0,
       translator.TranslatorByRegex(
-        [(r'(cflat|dead|delta|dsmear|hot|sap)_(\w+\.fit)', 0, r'../../calib/\1_\2')])),
+        [(r'cflat_grnd_SFA_(\w+\.fit)', 0, r'../../calib/cflat_grnd_sfa_\1'),
+         (r'(cflat|dead|delta|dsmear|hot|sap)_(\w+\.fit)', 0, r'../../calib/\1_\2')])),
     ('.*/NHxxMV_xxxx.*/NH..MV_2001/data/\w+/.*\.lbl', 0,
       translator.TranslatorByRegex(
         [(r'(mc[0-3])_(flat_\w+\.fit)s', 0, r'../../calib/mcl/\1_\2'),
@@ -665,10 +666,10 @@ def generate_links(dirpath, old_links={},
 
     Keys ending in .LBL, .CAT and .TXT return a list of tuples
         (recno, link, target)
-    for each link found found. Here,
-        recno = record number in file
-        link = the text of the link
-        target = absolute path to the target of the link
+    for each link found. Here,
+        recno = record number in file;
+        link = the text of the link;
+        target = absolute path to the target of the link.
 
     Other keys return a single string, which indicates the absolute path to the
     label file describing this file.
@@ -1120,7 +1121,7 @@ def load_links(dirpath, limits={}, logger=None):
     logger.open('Reading link shelf file for', dirpath, limits)
 
     try:
-        (link_path, lskip) = pdsdir.shelf_path_and_lskip(id='links')
+        (link_path, lskip) = pdsdir.shelf_path_and_lskip('link')
         prefix_ = pdsdir.volume_abspath() + '/'
 
         logger.info('Link shelf file', link_path)
@@ -1177,7 +1178,7 @@ def write_linkdict(dirpath, link_dict, limits={}, logger=None):
     logger.open('Writing link shelf file for', dirpath, limits)
 
     try:
-        (link_path, lskip) = pdsdir.shelf_path_and_lskip(id='links')
+        (link_path, lskip) = pdsdir.shelf_path_and_lskip('link')
         logger.info('Link shelf file', link_path)
 
         # Create a dictionary using interior paths instead of absolute paths
@@ -1382,7 +1383,7 @@ def move_old_links(shelf_file, logger=None):
 
 def initialize(pdsdir, logger=None):
 
-    link_path = pdsdir.shelf_path_and_lskip(id='links')[0]
+    link_path = pdsdir.shelf_path_and_lskip('link')[0]
 
     # Make sure file does not exist
     if os.path.exists(link_path):
@@ -1402,7 +1403,7 @@ def initialize(pdsdir, logger=None):
 
 def reinitialize(pdsdir, logger=None):
 
-    link_path = pdsdir.shelf_path_and_lskip(id='links')[0]
+    link_path = pdsdir.shelf_path_and_lskip('link')[0]
 
     # Warn if shelf file does not exist
     if not os.path.exists(link_path):
@@ -1423,7 +1424,7 @@ def reinitialize(pdsdir, logger=None):
 
 def validate(pdsdir, logger=None):
 
-    link_path = pdsdir.shelf_path_and_lskip(id='links')[0]
+    link_path = pdsdir.shelf_path_and_lskip('link')[0]
 
     # Make sure file exists
     if not os.path.exists(link_path):
@@ -1442,7 +1443,7 @@ def validate(pdsdir, logger=None):
 
 def repair(pdsdir, logger=None):
 
-    link_path = pdsdir.shelf_path_and_lskip(id='links')[0]
+    link_path = pdsdir.shelf_path_and_lskip('link')[0]
 
     # Make sure file exists
     if not os.path.exists(link_path):
@@ -1500,7 +1501,7 @@ def repair(pdsdir, logger=None):
 
 def update(pdsdir,  logger=None):
 
-    link_path = pdsdir.shelf_path_and_lskip(id='links')[0]
+    link_path = pdsdir.shelf_path_and_lskip('link')[0]
 
     # Make sure link shelf file exists
     if not os.path.exists(link_path):
@@ -1651,10 +1652,10 @@ if __name__ == '__main__':
                 continue
 
             # Save logs in up to two places
-            logfiles = set([pdsdir.log_path_for_volume(id='links',
+            logfiles = set([pdsdir.log_path_for_volume('_links',
                                                        task=args.task,
                                                        dir='pdslinkshelf'),
-                            pdsdir.log_path_for_volume(id='links',
+                            pdsdir.log_path_for_volume('_links',
                                                        task=args.task,
                                                        dir='pdslinkshelf',
                                                        place='parallel')])

--- a/validation/re-validate.py
+++ b/validation/re-validate.py
@@ -4,7 +4,7 @@
 #
 # Syntax:
 #   re-validate.py path [path ...]
-# 
+#
 # Enter the --help option to see more information.
 ################################################################################
 
@@ -44,9 +44,9 @@ def validate_one_volume(pdsdir, voltypes, tests, args, logger):
     tests_performed = 0
 
     # Open logger for this volume
-    logfiles = set([pdsdir.log_path_for_volume(id='re-validate',
+    logfiles = set([pdsdir.log_path_for_volume('_re-validate',
                                                dir='re-validate'),
-                    pdsdir.log_path_for_volume(id='re-validate',
+                    pdsdir.log_path_for_volume('_re-validate',
                                                dir='re-validate',
                                                place='parallel')])
 


### PR DESCRIPTION
Now as a set of changes relative to master branch. Minor bugfix to NHSP_xxxx. Otherwise, mainly an update to the validation tools for the reorganization. The only potential change that would affect the OPUS pipeline is that I renamed input arguments named "id" in the pdsfile methods log_path_for_volume, log_path_for_volset, shelf_path_and_lskip, and a few other shelf_path methods. This is because "id" is a python built-in, even though it is seldom used. This change would only affect the OPUS pipeline if you use one of these methods and explicitly refer to the first argument by name. I updated a few unit tests and they all pass. These versions of the validation tools are already running on Admin, serving as further evidence that this set of changes should not break anything.