### PR TITLE
Change retrieving viewable from warning to debug log

### DIFF
--- a/pdsfile.py
+++ b/pdsfile.py
@@ -1883,7 +1883,7 @@ class PdsFile(object):
 
         if len(self._info[4]) > 2:      # (0,0,'TBD') means fill in the size now
 
-            LOGGER.warn('Retrieving viewable shape', self.abspath)
+            LOGGER.debug('Retrieving viewable shape', self.abspath)
             try:
                 im = PIL.Image.open(self.abspath)
                 shape = im.size


### PR DESCRIPTION
- Fixes #74 

Assuming `use_shelves_only` is selected, PdsFile tries to get image dimensions (`.width` and `.height` properties) from the pickle (previously "shelve") files. Only if a pickle file doesn't exist does it look at the filesystem, read the image file, and derive the image dimensions that way. This used to be an indication of a problem, such as an old pickle file, but now it is a common occurrence. This is because the NH images `NH-Boresight-FOVs.png` and `LORRI-responsivity-plot.png` are in the `holdings/documents` directory, which doesn't have associated pickle files. Thus every time you access one of those files, you get a warning message in the log file, even though this really shouldn't be a warning. During OPUS import, this happens for every single NH observation, making the warnings output nearly unusable.

This pull simply changes that warning message to a debug message, which is more appropriate.

