### PR TITLE
Setup test directory under Pds4File

### DIFF
--- a/Pds4File/tests/conftest.py
+++ b/Pds4File/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+import pdsfile
+import pdslogger
+import pytest
+
+try:
+    PDS4_HOLDINGS_DIR = os.environ['PDS4_HOLDINGS_DIR']
+except KeyError: # pragma: no cover
+    # TODO: update this when we know the actual path of pds4 holdings on the webserver
+    PDS4_HOLDINGS_DIR = os.path.realpath('/Library/WebServer/Documents/holdings')
+
+################################################################################
+# Setup before all tests
+################################################################################
+@pytest.fixture(scope='session', autouse=True)
+def setup(request):
+    pdsfile.use_shelves_only(False) # pragma: no cover
+    pdsfile.preload(PDS4_HOLDINGS_DIR)

--- a/Pds4File/tests/helper.py
+++ b/Pds4File/tests/helper.py
@@ -1,0 +1,17 @@
+import os
+import pds4file
+
+try:
+    PDS4_HOLDINGS_DIR = os.environ['PDS4_HOLDINGS_DIR']
+except KeyError: # pragma: no cover
+    # TODO: update this when we know the actual path of pds4 holdings on the webserver
+    PDS4_HOLDINGS_DIR = os.path.realpath('/Library/WebServer/Documents/holdings')
+
+def instantiate_target_pdsfile(path, is_abspath=True):
+    if is_abspath:
+        TESTFILE_PATH = PDS4_HOLDINGS_DIR + '/' + path
+        target_pdsfile = pds4file.PdsFile.from_abspath(TESTFILE_PATH)
+    else:
+        TESTFILE_PATH = path
+        target_pdsfile = pds4file.PdsFile.from_logical_path(TESTFILE_PATH)
+    return target_pdsfile

--- a/Pds4File/tests/test_pds4file_blackbox.py
+++ b/Pds4File/tests/test_pds4file_blackbox.py
@@ -1,0 +1,39 @@
+import os
+import pytest
+
+from tests.helper import instantiate_target_pdsfile
+
+# Check environment variables or else look in the default places
+try:
+    PDS4_HOLDINGS_DIR = os.environ['PDS4_HOLDINGS_DIR']
+except KeyError: # pragma: no cover
+    # TODO: update this when we know the actual path of pds4 holdings on the webserver
+    PDS4_HOLDINGS_DIR = os.path.realpath('/Library/WebServer/Documents/holdings')
+
+################################################################################
+# Blackbox tests for pds4file.py
+################################################################################
+class TestPds4FileBlackBox:
+    @pytest.mark.parametrize(
+        'input_path,expected',
+        [
+            ('uranus_occs_earthbased/uranus_occ_u0_kao_91cm/data/atmosphere/u0_kao_91cm_734nm_counts-v-time_atmos_ingress.xml',
+             'opus-id-placehodler'),
+        ]
+    )
+    def test_opus_id(self, input_path, expected):
+        target_pdsfile = instantiate_target_pdsfile(input_path)
+        res = target_pdsfile.opus_id
+        assert res == expected
+
+    @pytest.mark.parametrize(
+        'input_path,expected',
+        [
+            ('uranus_occs_earthbased/uranus_occ_u0_kao_91cm',
+             f'{PDS4_HOLDINGS_DIR}/uranus_occs_earthbased/uranus_occ_u0_kao_91cm'),
+        ]
+    )
+    def test_abspath(self, input_path, expected):
+        target_pdsfile = instantiate_target_pdsfile(input_path)
+        res = target_pdsfile.abspath
+        assert res == expected


### PR DESCRIPTION
Note: test directory is set up under Pds4File
- Make sure to set environment variable `PDS4_HOLDINGS_DIR` to the path of pds4 testing directory (`{your local path to dropbox}/Pds4FileTest/pds4-holdings/bundles`)
- Currently only two tests exist in the test script
- Command to run if we are under pds-webtools directory: `pytest Pds4File/tests/`
- Command to run if we are under Pds4File directory: `pytest tests/`
