### PR TITLE
Fixed broken viewmaster caused by error in `.checksum` and remove tiff from viewable extension

### DIFF
--- a/pdsfile.py
+++ b/pdsfile.py
@@ -36,7 +36,7 @@ VOLTYPES = ['volumes', 'calibrated', 'diagrams', 'metadata', 'previews',
             'documents']
 VIEWABLE_VOLTYPES = ['previews', 'diagrams']
 
-VIEWABLE_EXTS = set(['jpg', 'png', 'gif', 'tif', 'tiff', 'jpeg', 'jpeg_small'])
+VIEWABLE_EXTS = set(['jpg', 'png', 'gif', 'jpeg', 'jpeg_small'])
 DATAFILE_EXTS = set(['dat', 'img', 'cub', 'qub', 'fit', 'fits'])
 
 VOLSET_REGEX        = re.compile(r'^([A-Z][A-Z0-9x]{1,5}_[0-9x]{3}x)$')

--- a/pdsfile.py
+++ b/pdsfile.py
@@ -36,7 +36,7 @@ VOLTYPES = ['volumes', 'calibrated', 'diagrams', 'metadata', 'previews',
             'documents']
 VIEWABLE_VOLTYPES = ['previews', 'diagrams']
 
-VIEWABLE_EXTS = set(['jpg', 'png', 'gif', 'jpeg', 'jpeg_small'])
+VIEWABLE_EXTS = set(['jpg', 'png', 'gif', 'tif', 'tiff', 'jpeg', 'jpeg_small'])
 DATAFILE_EXTS = set(['dat', 'img', 'cub', 'qub', 'fit', 'fits'])
 
 VOLSET_REGEX        = re.compile(r'^([A-Z][A-Z0-9x]{1,5}_[0-9x]{3}x)$')

--- a/pdsfile.py
+++ b/pdsfile.py
@@ -1305,12 +1305,10 @@ class PdsFile(object):
                     # If the shelf file is missing, try the actual file system
                     # For documentation, we have all files available but not the shelf
                     # files, therefore we will check the actual file system for documents.
-                    if '/holdings/documents' in abspath:
-                        childnames = os.listdir(abspath)
-                        return [c for c in childnames
-                                if c != '.DS_Store' and not c.startswith('._')]
-                    else:
-                        return []
+                    childnames = os.listdir(abspath)
+                    return [c for c in childnames
+                            if c != '.DS_Store' and not c.startswith('._')]
+
                 if not results:
                     return []
 

--- a/pdsfile.py
+++ b/pdsfile.py
@@ -1305,10 +1305,12 @@ class PdsFile(object):
                     # If the shelf file is missing, try the actual file system
                     # For documentation, we have all files available but not the shelf
                     # files, therefore we will check the actual file system for documents.
-                    childnames = os.listdir(abspath)
-                    return [c for c in childnames
-                            if c != '.DS_Store' and not c.startswith('._')]
-
+                    if '/holdings/documents' in abspath:
+                        childnames = os.listdir(abspath)
+                        return [c for c in childnames
+                                if c != '.DS_Store' and not c.startswith('._')]
+                    else:
+                        return []
                 if not results:
                     return []
 
@@ -4634,7 +4636,7 @@ class PdsFile(object):
         """
         # we don't have shelf files for documents
         if self.is_documents:
-            return
+            return []
 
         (shelf_path, key) = self.shelf_path_and_key(shelf_type, volname)
 

--- a/pdsfile.py
+++ b/pdsfile.py
@@ -4634,9 +4634,6 @@ class PdsFile(object):
         volname         can be used to get info about a volume when the method
                         is applied to its enclosing volset.
         """
-        # we don't have shelf files for documents
-        if self.is_documents:
-            return []
 
         (shelf_path, key) = self.shelf_path_and_key(shelf_type, volname)
 

--- a/tests/test_pdsfile_blackbox.py
+++ b/tests/test_pdsfile_blackbox.py
@@ -640,7 +640,14 @@ class TestPdsFileBlackBox:
         'input_path,expected',
         [
             ('previews/COUVIS_0xxx/COUVIS_0009/DATA/D2004_274/EUV2004_274_01_39_thumb.png',
-             'f43e6fe3d9eb02ed72e0aba47be443f2')
+             'f43e6fe3d9eb02ed72e0aba47be443f2'),
+            ('documents/COCIRS_0xxx', ''),
+            ('documents/COCIRS_5xxx', ''),
+            ('documents/COCISS_0xxx', ''),
+            ('documents/COUVIS_0xxx', ''),
+            ('documents/COUVIS_8xxx', ''),
+            ('documents/COVIMS_0xxx', ''),
+            ('documents/COVIMS_8xxx', ''),
         ]
     )
     def test_checksum(self, input_path, expected):


### PR DESCRIPTION
- Fixed [#70](https://github.com/SETI/pds-webserver/issues/70) Fixed #83
- Changes:
  - Removed 'tif' and 'tiff' from the VIEWABLE_EXTS
  - Fixed the error of checksum property for the pdsfile instance by removing the wrong return value of shelf_lookup for pdsfile instances of documents directory.
  - Add tests on checksum for pdsfile instances of documents directory.