### PR TITLE
Add shelf exists if expected function

### DIFF
--- a/pdsfile.py
+++ b/pdsfile.py
@@ -4733,6 +4733,21 @@ class PdsFile(object):
         # This leaves volset-level files and their AAREADMEs
         return False
 
+    def shelf_exists_if_expected(self):
+        """True if shelf exists for a pdsfile instance expected to have one. False if
+        shelf doesn't exist for a pdsfile instance expected to have one or a pdsfile
+        instance not expected to have one."""
+
+        if not self.info_shelf_expected:
+            return False
+        else:
+            try:
+                self.shelf_lookup('info')
+                return True
+            except OSError:
+                return False
+
+
     ############################################################################
     # Log path associations
     ############################################################################

--- a/pdsfile.py
+++ b/pdsfile.py
@@ -4734,19 +4734,18 @@ class PdsFile(object):
         return False
 
     def shelf_exists_if_expected(self):
-        """True if shelf exists for a pdsfile instance expected to have one. False if
-        shelf doesn't exist for a pdsfile instance expected to have one or a pdsfile
-        instance not expected to have one."""
+        """True if shelf exists for a pdsfile instance expected to have the shelf file.
+        False if shelf doesn't exist for a pdsfile instance expected to have one."""
 
-        if not self.info_shelf_expected:
-            return False
-        else:
+        if self.info_shelf_expected:
             try:
                 self.shelf_lookup('info')
                 return True
             except OSError:
                 return False
 
+        # Return None if a pdsfile instance doesn't expect the shelf file
+        return None
 
     ############################################################################
     # Log path associations

--- a/pdsfile.py
+++ b/pdsfile.py
@@ -36,7 +36,7 @@ VOLTYPES = ['volumes', 'calibrated', 'diagrams', 'metadata', 'previews',
             'documents']
 VIEWABLE_VOLTYPES = ['previews', 'diagrams']
 
-VIEWABLE_EXTS = set(['jpg', 'png', 'gif', 'tif', 'tiff', 'jpeg', 'jpeg_small'])
+VIEWABLE_EXTS = set(['jpg', 'png', 'gif', 'jpeg', 'jpeg_small'])
 DATAFILE_EXTS = set(['dat', 'img', 'cub', 'qub', 'fit', 'fits'])
 
 VOLSET_REGEX        = re.compile(r'^([A-Z][A-Z0-9x]{1,5}_[0-9x]{3}x)$')

--- a/tests/test_pdsfile_blackbox.py
+++ b/tests/test_pdsfile_blackbox.py
@@ -1029,6 +1029,20 @@ class TestPdsFileBlackBox:
         assert isinstance(res, pdsfile.PdsFile)
         assert res.abspath == expected
 
+    @pytest.mark.parametrize(
+        'input_path,expected',
+        [
+            ('volumes/COVIMS_0xxx/COVIMS_0001/data/1999017T031657_1999175T202056/v1308946681_1_002.qub',
+             True),
+            ('documents/COCIRS_0xxx/Chan-etal-2015.link',
+             None),
+        ]
+    )
+    def test_shelf_exists_if_expected(self, input_path, expected):
+        target_pdsfile = instantiate_target_pdsfile(input_path)
+        res = target_pdsfile.shelf_exists_if_expected()
+        assert res == expected
+
     ############################################################################
     # Test for OPUS support methods
     ############################################################################


### PR DESCRIPTION
- Create a new function `shelf_exists_if_expected` in `pdsfile.py`. It will be call in opus `do_import.py` to check if the shelves/info files exist for a pdsfile instance expecting the shelf file.
- This will work with https://github.com/SETI/pds-opus/pull/1311/files